### PR TITLE
Add default values for PF_DIRNAME items

### DIFF
--- a/startrail.py
+++ b/startrail.py
@@ -210,11 +210,11 @@ register(
 	_("Startrail"),
 	"",
 	[
-		(PF_DIRNAME, "frames","Light Frames",""),
+		(PF_DIRNAME, "frames","Light Frames","/tmp"),
 		(PF_TOGGLE, "use_dark_frames","Use dark frame",0),
-		(PF_DIRNAME, "dark_frames","Dark Frames",""),
+		(PF_DIRNAME, "dark_frames","Dark Frames","/tmp"),
 		(PF_TOGGLE, "save_intermediate","Save intermediate frames",0),
-		(PF_DIRNAME, "save_directory","Intermediate save directory",""),
+		(PF_DIRNAME, "save_directory","Intermediate save directory","/tmp"),
 		(PF_TOGGLE, "live_display","Live display update (much slower)",0),
 		(PF_TOGGLE, "merge_layers","Merge all images to a single layer",1),
 		(PF_TOGGLE, "subtract_skyglow","Automatically remove skyglow (much slower)",0)


### PR DESCRIPTION
Added a default value /tmp to the PF_DIRNAME items in the registration section. This prevents crashes when trying to select a folder. I tested it on windows, and it was mentioned on stackexchange as a fix for the issue on Linux as well.