### PR TITLE
Disable undo history when creating star trail

### DIFF
--- a/startrail.py
+++ b/startrail.py
@@ -93,6 +93,7 @@ def process_light_frame(file_name, image, dark_image, merge_layers, image_count,
 	if image == None:
 		# create a base image based on the light frame
 		image = get_new_image(light_frame)
+		image.disable_undo()
 
 	# did we make a dark frame?
 	if dark_image != None:
@@ -191,6 +192,7 @@ def startrail(frames, use_dark_frames, dark_frames, save_intermediate, save_dire
 		pdb.gimp_message("No images found to stack")
 
 	if image != None:
+		image.enable_undo()
 		if live_display == 1 :
 			gimp.displays_flush()
 		else:


### PR DESCRIPTION
When creating star trails, GIMP will save undo history for every
operation that is run. This can easily result in GIMP consuming
many GB of data for the final image. Disabling undo history on
the image keeps the memory usage under control.

Signed-off-by: Daniel P. Berrange <berrange@redhat.com>